### PR TITLE
Added `amixr_integration.link` attribute

### DIFF
--- a/amixr/resource_integration.go
+++ b/amixr/resource_integration.go
@@ -60,6 +60,10 @@ func resourceIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"templates": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -163,6 +167,7 @@ func resourceIntegrationRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", integration.Name)
 	d.Set("type", integration.Type)
 	d.Set("templates", flattenTemplates(integration.Templates))
+	d.Set("link", integration.Link)
 
 	return nil
 }

--- a/amixr/resource_integration_test.go
+++ b/amixr/resource_integration_test.go
@@ -25,6 +25,7 @@ func TestAccAmixrIntegration_basic(t *testing.T) {
 					testAccCheckAmixrIntegrationResourceExists("amixr_integration.test-acc-integration"),
 					resource.TestCheckResourceAttr("amixr_integration.test-acc-integration", "name", rName),
 					resource.TestCheckResourceAttr("amixr_integration.test-acc-integration", "type", rType),
+					resource.TestCheckResourceAttrSet("amixr_integration.test-acc-integration", "link"),
 				),
 			},
 		},

--- a/website/docs/r/integration.html.markdown
+++ b/website/docs/r/integration.html.markdown
@@ -61,6 +61,7 @@ The following arguments are supported:
 The following attributes are exported:
 
   * `id` - The ID of the integration.
+  * `link` - Link for using in an integrated tool.
   
 
 ## Import


### PR DESCRIPTION
Attribute `amixr_integration.link` added to be able to configure integrated tool in place f.e.

```
resource "amixr_integration" "alertmanager" {
  name = "Alertmanager"
  type = "alertmanager"
}

locals {
  values = {
    alertmanagerFiles = {
      "alertmanager.yml" = {
        receivers = [{
          webhook_configs = [{ url = var.amixr_alertmanager_integration_link }]
          . . .
```